### PR TITLE
Some testthat tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,8 @@ Encoding: UTF-8
 LazyData: true
 Imports: igraph,
     Rcpp
-Suggests: gbp
+Suggests: 
+    gbp,
+    testthat
 LinkingTo: Rcpp
 RoxygenNote: 6.0.1

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(smglr)
+
+test_check("smglr")

--- a/tests/testthat/test-stress_majorization.R
+++ b/tests/testthat/test-stress_majorization.R
@@ -1,0 +1,64 @@
+context("Test stress_majorization() on connected graphs")
+
+requireNamespace("igraph")
+
+
+test_that("it works on directed connected graph", {
+  g <- igraph::make_graph( ~ a -+ b +-+ c -+ d:e:f)
+  expect_silent(
+    r <- stress_majorization(g)
+  )
+  expect_is(r, "matrix")
+})
+
+
+
+test_that("it works on undirected connected graph", {
+  g <- igraph::make_graph( ~ a -- b -- c -- d:e:f)
+  expect_silent(
+    r <- stress_majorization(g)
+  )
+  expect_is(r, "matrix")
+})
+
+
+
+
+
+
+
+context("stress_majorization() works on disconnected graphs")
+
+test_that("it works on an isolate", {
+  g <- igraph::make_graph( ~ a)
+  expect_silent(
+    r <- stress_majorization(g)
+  )
+  expect_is(r, "matrix")
+})
+
+test_that("it works on a graph of 5 isolates", {
+  g <- igraph::make_graph( ~ a, b, c, d, e)
+  expect_silent(
+    r <- stress_majorization(g)
+  )
+  expect_is(r, "matrix")
+})
+
+test_that("it works on an undirected graph of two connected dyads", {
+  g <- igraph::make_graph( ~ a -- b, c -- d)
+  expect_silent(
+    r <- stress_majorization(g)
+  )
+  expect_is(r, "matrix")
+})
+
+
+test_that("it works on an undirected graph of two connected dyads with 5 isolates", {
+  g <- igraph::make_graph( ~ a -- b, c -- d, e, f, g, h, i)
+  expect_silent(
+    r <- stress_majorization(g)
+  )
+  expect_is(r, "matrix")
+})
+


### PR DESCRIPTION
Some `testthat` tests. I wrote them assuming that a call `stress_majorization(g)` should return something useful whatever the structure of `g`. In particular this assumes that it should work if

- `g` is empty (to be added)
- `g` consists of only isolates

These tests don't pass for the current version of the package. Nevertheless I think following "confirmatory programming"  (see slides 15-16 of https://scholarship.rice.edu/bitstream/handle/1911/36084/r-packages.key.pdf) here a bit is OK.